### PR TITLE
CI: run platform-specific tests and install libcurl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
-        run: ./gradlew allTests assembleJWTKMPXCFramework --no-configuration-cache
+        # Don't run `allTests` on macOS: it includes non-Apple Kotlin/Native targets
+        # (e.g. linuxX64Test) which aren't meant to be linked/run here.
+        run: ./gradlew macosArm64Test iosSimulatorArm64Test assembleJWTKMPXCFramework --no-configuration-cache
 
   build-linux:
     name: Build and Test (Linux / Android / JS / WASM)
@@ -44,8 +46,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Build and test
-        run: ./gradlew allTests --no-configuration-cache
+        # Prefer node-based JS/WASM tests in CI to avoid requiring a browser runner.
+        run: ./gradlew jvmTest jsNodeTest wasmJsNodeTest linuxX64Test --no-configuration-cache
 
   build-windows:
     name: Build and Test (Windows)


### PR DESCRIPTION
Fixes CI failures after the recent workflow/memory cleanup.

- macOS: avoid running `allTests` (it includes non-Apple native targets like `linuxX64Test`)
- Linux: install `libcurl4-openssl-dev` for Ktor curl engine linking
- Linux: run node-based JS/WASM tests + `linuxX64Test` + `jvmTest` instead of `allTests`
