### PR TITLE
CI: fix Linux workflow task list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and test
         # Prefer node-based JS/WASM tests in CI to avoid requiring a browser runner.
-        run: ./gradlew jvmTest jsNodeTest wasmJsNodeTest linuxX64Test --no-configuration-cache
+        run: ./gradlew jsNodeTest wasmJsNodeTest linuxX64Test --no-configuration-cache
 
   build-windows:
     name: Build and Test (Windows)


### PR DESCRIPTION
Fixes Linux CI failure by removing the `jvmTest` task; this repo has no JVM target.